### PR TITLE
Populate the label 'for' with the control id

### DIFF
--- a/FluentBootstrap.Mvc/Forms/FormControlOverride.cs
+++ b/FluentBootstrap.Mvc/Forms/FormControlOverride.cs
@@ -13,9 +13,6 @@ namespace FluentBootstrap.Mvc.Forms
     {
         protected override void OnStart(TextWriter writer)
         {
-            Component.Prepare(writer);
-
-            // Add the validation data
             string name = Component.GetAttribute("name");
             if (!string.IsNullOrWhiteSpace(name))
             {
@@ -28,7 +25,13 @@ namespace FluentBootstrap.Mvc.Forms
                 }
                 tagBuilder.GenerateId(name);
                 Component.MergeAttribute("id", tagBuilder.Attributes["id"]);
+            }
 
+            Component.Prepare(writer);
+
+            // Add the validation data
+            if (!string.IsNullOrWhiteSpace(name))
+            {
                 // Set the validation class
                 ModelState modelState;
                 MvcBootstrapConfig<TModel> config = (MvcBootstrapConfig<TModel>)Config;

--- a/FluentBootstrap.Mvc/Forms/MvcFormExtensions.cs
+++ b/FluentBootstrap.Mvc/Forms/MvcFormExtensions.cs
@@ -389,7 +389,7 @@ namespace FluentBootstrap
             this ComponentBuilder<MvcBootstrapConfig<TModel>, TFormControl> builder, Expression<Func<TModel, TValue>> expression, Action<ControlLabel> labelAction = null)
             where TFormControl : FormControl
         {
-            ControlLabel controlLabel = GetControlLabel(builder.GetHelper(), expression).For(builder.GetComponent().GetAttribute("name")).GetComponent();
+            ControlLabel controlLabel = GetControlLabel(builder.GetHelper(), expression).For(TagBuilder.CreateSanitizedId(builder.GetComponent().GetAttribute("name"))).GetComponent();
             if (labelAction != null)
             {
                 labelAction(controlLabel);
@@ -406,14 +406,13 @@ namespace FluentBootstrap
             ModelMetadata metadata = ModelMetadata.FromLambdaExpression(expression, helper.GetConfig().HtmlHelper.ViewData);
             string name = GetControlName(helper, expressionText);
             string label = GetControlLabel(metadata, expressionText);
-            return new MvcBootstrapHelper<TModel>(helper.GetConfig().HtmlHelper).ControlLabel(label).For(name);
+            return new MvcBootstrapHelper<TModel>(helper.GetConfig().HtmlHelper).ControlLabel(label).For(TagBuilder.CreateSanitizedId(name));
         }
 
         private static string GetControlName<TComponent, TModel>(BootstrapHelper<MvcBootstrapConfig<TModel>, TComponent> helper, string expressionText)
             where TComponent : Component
         {
-            return TagBuilder.CreateSanitizedId(
-                helper.GetConfig().HtmlHelper.ViewContext.ViewData.TemplateInfo.GetFullHtmlFieldName(expressionText));
+            return helper.GetConfig().HtmlHelper.ViewContext.ViewData.TemplateInfo.GetFullHtmlFieldName(expressionText);
         }
 
         private static string GetControlLabel(ModelMetadata metadata, string expressionText)

--- a/FluentBootstrap.Tests.Web/Models/MvcTests/ViewModel.cs
+++ b/FluentBootstrap.Tests.Web/Models/MvcTests/ViewModel.cs
@@ -14,5 +14,12 @@ namespace FluentBootstrap.Tests.Web.Models.MvcTests
         public string PropC { get; set; }
         public Dictionary<int, string> PropCOptions { get; set; }
         public bool PropD { get; set; }
+        public ChildModel Child { get; set; }
+    }
+
+    public class ChildModel
+    {
+        [Display(Name = "Child Property A")]
+        public string ChildPropA { get; set; }
     }
 }

--- a/FluentBootstrap.Tests.Web/Views/MvcTests/MvcForms.cshtml
+++ b/FluentBootstrap.Tests.Web/Views/MvcTests/MvcForms.cshtml
@@ -139,4 +139,13 @@
             @form.SelectFor(x => x.PropC).AddOptions(Model.PropCOptions.Select(y => new KeyValuePair<string, string>(y.Key.ToString(), y.Value)))
         }
     }
+    
+    @Html.Bootstrap().Heading1("Input For With Dotted Child")
+    using (Html.Bootstrap().Div().SetId("test-input-for-dotted").Begin())
+    {
+        using (var form = Html.Bootstrap().Form().HideValidationSummary().Begin())
+        {
+            @form.InputFor(x => x.Child.ChildPropA)
+        }
+    }
 }

--- a/FluentBootstrap.Tests/MvcFormsFixture.cs
+++ b/FluentBootstrap.Tests/MvcFormsFixture.cs
@@ -191,5 +191,17 @@ namespace FluentBootstrap.Tests
    </div>
   </form>");
         }
+
+        [Test]
+        public void InputForDottedProducesCorrectHtml()
+        {
+            TestHelper.AssertMvcHtml<ASP._Views_MvcTests_MvcForms_cshtml>("test-input-for-dotted",
+@"<form role=""form"" method=""post"">
+   <div class=""form-group"">
+    <label for=""Child_ChildPropA"" class=""control-label"">Child Property A</label>
+    <input type=""text"" name=""Child.ChildPropA"" id=""Child_ChildPropA"" class=""form-control"">
+   </div>
+  </form>");
+        }
     }
 }

--- a/FluentBootstrap.Tests/TestHelper.cs
+++ b/FluentBootstrap.Tests/TestHelper.cs
@@ -82,7 +82,11 @@ namespace FluentBootstrap.Tests
                     { 2, "Two"},
                     { 3, "Three"}
                 },
-                PropD = true
+                PropD = true,
+                Child = new ChildModel()
+                {
+                    ChildPropA = "ChildA"
+                }
             };
             HtmlDocument doc = Render<TView, ViewModel>(model);
             expected = expected.Replace("\r\n", "\n");

--- a/FluentBootstrap/Forms/FormControl.cs
+++ b/FluentBootstrap/Forms/FormControl.cs
@@ -81,11 +81,11 @@ namespace FluentBootstrap.Forms
             // Add the label to the form group or write it
             if (_label != null)
             {
-                // Set the label's for attribute to the input name
-                string name = Attributes.GetValue("name");
-                if (!string.IsNullOrWhiteSpace(name))
+                // Set the label's for attribute to the input id
+                string id = Attributes.GetValue("id");
+                if (!string.IsNullOrWhiteSpace(id))
                 {
-                    _label.MergeAttribute("for", name);
+                    _label.MergeAttribute("for", id);
                 }
 
                 // Add or write the label


### PR DESCRIPTION
The label 'for' attribute should reflect the id of the labelled control, not the name.

The population of the 'for' attribute for the label has been tied to the name field of the attached control. This has worked fine when using a simple property in the control expression, since the id and name are always equivalent, such as:

```
Html.Bootstrap().InputFor(x => x.PropA)
generates
    <label for="PropA" class="control-label">Property A</label>
    <input type="text" name="PropA" id="PropA" class="form-control">
```

However if a complex expression is used, then the input 'id' must be sanitized, and the `name` must remain unsanitized so that the complex model can be model bound when posted. With the existing code the name is also sanitized, which breaks the default MVC model binding for complex properties.

```
Html.Bootstrap().InputFor(x => x.Child.ChildPropA)
should generate
    <label for="Child_ChildPropA" class="control-label">Child Property A</label>
    <input type="text" name="Child.ChildPropA" id="Child_ChildPropA" class="form-control">
```

This change implements this correct behaviour for complex properties.